### PR TITLE
Add a link to minecraft bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ScheCPUEmulator
 
 URL: https://github.com/schemil053/ScheCPUEmulator
+
 Minecraft Bridge: https://github.com/schemil053/ScheCPUMinecraft
 
 ## Languages

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ScheCPUEmulator
 
 URL: https://github.com/schemil053/ScheCPUEmulator
+Minecraft Bridge: https://github.com/schemil053/ScheCPUMinecraft
 
 ## Languages
 - [English](#english)

--- a/README_DE.md
+++ b/README_DE.md
@@ -1,6 +1,7 @@
 # ScheCPUEmulator
 
 URL: https://github.com/schemil053/ScheCPUEmulator
+Minecraft-Brücke: https://github.com/schemil053/ScheCPUMinecraft
 
 ## Sprachen
 - [Englisch](README.md)

--- a/README_DE.md
+++ b/README_DE.md
@@ -1,6 +1,7 @@
 # ScheCPUEmulator
 
 URL: https://github.com/schemil053/ScheCPUEmulator
+
 Minecraft-Brücke: https://github.com/schemil053/ScheCPUMinecraft
 
 ## Sprachen


### PR DESCRIPTION
Hello schemil053,

I updated the readme files to link your bukkit implementation.

I don't think you do a forge/fabric implementation, so I called it "minecraft bridge".
I also translated it to german.

